### PR TITLE
Fix continue statement within switch/case keeping original behavior

### DIFF
--- a/lib/Horde/Mail/Rfc822.php
+++ b/lib/Horde/Mail/Rfc822.php
@@ -571,7 +571,7 @@ class Horde_Mail_Rfc822
                 if (substr($str, -1) == "\r") {
                     $str = substr($str, 0, -1);
                 }
-                continue;
+                break;
 
             case '\\':
                 if (($chr = $this->_curr(true)) === false) {
@@ -737,7 +737,7 @@ class Horde_Mail_Rfc822
             case "\r":
             case "\t":
                 ++$this->_ptr;
-                continue;
+                break;
 
             case '(':
                 $this->_rfc822SkipComment();
@@ -765,7 +765,7 @@ class Horde_Mail_Rfc822
             switch ($chr) {
             case '(':
                 ++$level;
-                continue;
+                break;
 
             case ')':
                 if (--$level == 0) {


### PR DESCRIPTION
continue statements within switch/case statements always have
behaved like break (ending the switch). Only exception is when
they are within a loop and we may want to use 'continue 2;'
instead (to jump to next iteration).

PHP7.3 has added a PHPWarning for all this switch/case/continue
uses (https://wiki.php.net/rfc/continue_on_switch_deprecation) so
this just changes is to the BC equivalent break. As far as there
isn't remaining code in the loop after the switch, it is 100%
the same than a continue 2.