### PR TITLE
Fix RFC822 address nullable personal attribute

### DIFF
--- a/lib/Horde/Mail/Rfc822.php
+++ b/lib/Horde/Mail/Rfc822.php
@@ -406,7 +406,7 @@ class Horde_Mail_Rfc822
         if ($this->_curr() == '@') {
             try {
                 $this->_rfc822ParseDomain($host);
-                if (strlen($host)) {
+                if (!empty($host)) {
                     $ob->host = $host;
                 }
             } catch (Horde_Mail_Exception $e) {
@@ -647,7 +647,7 @@ class Horde_Mail_Rfc822
                 /* TODO: Optimize by duplicating rfc822IsAtext code here */
                 !$this->_rfc822IsAtext($chr, ',<:')) {
                 $this->_rfc822SkipLwsp();
-                if (!$this->_params['validate']) {
+                if (!$this->_params['validate'] && $str !== null) {
                     $str = trim($str);
                 }
                 return;

--- a/lib/Horde/Mail/Rfc822/Address.php
+++ b/lib/Horde/Mail/Rfc822/Address.php
@@ -99,7 +99,7 @@ class Horde_Mail_Rfc822_Address extends Horde_Mail_Rfc822_Object
             break;
 
         case 'personal':
-            $this->_personal = strlen($value)
+            $this->_personal = !empty($value)
                 ? Horde_Mime::decode($value)
                 : null;
             break;
@@ -144,7 +144,7 @@ class Horde_Mail_Rfc822_Address extends Horde_Mail_Rfc822_Object
                 : $this->_personal;
 
         case 'personal':
-            return (strcasecmp($this->_personal, $this->bare_address) === 0)
+            return $this->_personal === null || (strcasecmp($this->_personal, $this->bare_address) === 0)
                 ? null
                 : $this->_personal;
 
@@ -152,7 +152,7 @@ class Horde_Mail_Rfc822_Address extends Horde_Mail_Rfc822_Object
             return Horde_Mime::encode($this->personal);
 
         case 'valid':
-            return (bool)strlen($this->mailbox);
+            return !empty($this->mailbox);
         }
     }
 
@@ -164,11 +164,11 @@ class Horde_Mail_Rfc822_Address extends Horde_Mail_Rfc822_Object
 
         $address = $rfc822->encode($this->mailbox, 'address');
         $host = empty($opts['idn']) ? $this->host : $this->host_idn;
-        if (strlen($host)) {
+        if (!empty($host)) {
             $address .= '@' . $host;
         }
         $personal = $this->personal;
-        if (strlen($personal)) {
+        if (!empty($personal)) {
             if (!empty($opts['encode'])) {
                 $personal = Horde_Mime::encode($this->personal, $opts['encode']);
             }
@@ -182,7 +182,7 @@ class Horde_Mail_Rfc822_Address extends Horde_Mail_Rfc822_Object
             }
         }
 
-        return (strlen($personal) && ($personal != $address))
+        return (!empty($personal) && ($personal != $address))
             ? ltrim($personal) . ' <' . $address . '>'
             : $address;
     }

--- a/lib/Horde/Mail/Rfc822/Identification.php
+++ b/lib/Horde/Mail/Rfc822/Identification.php
@@ -44,11 +44,11 @@ class Horde_Mail_Rfc822_Identification extends Horde_Mail_Rfc822
     /**
      * Parse an identification header.
      *
-     * @param string $value  Identification field value to parse.
+     * @param string|null $value  Identification field value to parse.
      */
     public function parse($value)
     {
-        if (!strlen($value)) {
+        if (empty($value)) {
             return;
         }
 

--- a/lib/Horde/Mail/Transport.php
+++ b/lib/Horde/Mail/Transport.php
@@ -208,7 +208,7 @@ abstract class Horde_Mail_Transport
     protected function _sanitizeHeaders($headers)
     {
         foreach (array_diff(array_keys($headers), array('_raw')) as $key) {
-            $headers[$key] = preg_replace('=((<CR>|<LF>|0x0A/%0A|0x0D/%0D|\\n|\\r)\S).*=i', null, $headers[$key]);
+            $headers[$key] = preg_replace('=((<CR>|<LF>|0x0A/%0A|0x0D/%0D|\\n|\\r)\S).*=i', '', $headers[$key]);
         }
 
         return $headers;
@@ -251,7 +251,7 @@ abstract class Horde_Mail_Transport
             }
         }
 
-        if (!strlen($from)) {
+        if (empty($from)) {
             throw new Horde_Mail_Exception('No from address provided.');
         }
 


### PR DESCRIPTION
As of PHP8.1 many string functions do not accept null anymore. Therefore
more explicit null checks or alternative functions need to be used.

The errors I found are the following:

```
Passing null to parameter #1 ($string1) of type string is deprecated at Horde_Mail/Horde/Mail/Rfc822/Address.php#147
Passing null to parameter #1 ($string) of type string is deprecated at Horde_Mail/Horde/Mail/Rfc822/Address.php#185
Passing null to parameter #3 ($subject) of type array|string is deprecated at Horde_Mime/Horde/Mime/Headers/Element.php#145
Passing null to parameter #1 ($string) of type string is deprecated at Horde_Mail/Horde/Mail/Rfc822/Address.php#171
Passing null to parameter #1 ($string) of type string is deprecated at Horde_Mail/Horde/Mail/Rfc822/Address.php#102
Passing null to parameter #1 ($string) of type string is deprecated at Horde_Mail/Horde/Mail/Rfc822.php#651
Passing null to parameter #1 ($string) of type string is deprecated at Horde_Mail/Horde/Mail/Rfc822/Identification.php#51
``` 