### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/lib/Horde/Mail/Mbox/Parse.php
+++ b/lib/Horde/Mail/Mbox/Parse.php
@@ -133,6 +133,7 @@ implements ArrayAccess, Countable, Iterator
 
     /**
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->_parsed[$offset]);
@@ -140,6 +141,7 @@ implements ArrayAccess, Countable, Iterator
 
     /**
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if (!isset($this->_parsed[$offset])) {
@@ -179,6 +181,7 @@ implements ArrayAccess, Countable, Iterator
 
     /**
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         // NOOP
@@ -186,6 +189,7 @@ implements ArrayAccess, Countable, Iterator
 
     /**
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         // NOOP
@@ -198,6 +202,7 @@ implements ArrayAccess, Countable, Iterator
      *
      * @return integer  The number of messages.
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->_parsed);
@@ -217,7 +222,7 @@ implements ArrayAccess, Countable, Iterator
     }
 
     /* Iterator methods. */
-
+    #[\ReturnTypeWillChange]
     public function current()
     {
         $key = $this->key();
@@ -227,11 +232,13 @@ implements ArrayAccess, Countable, Iterator
             : $this[$key];
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return key($this->_parsed);
     }
 
+    #[\ReturnTypeWillChange]
     public function next()
     {
         if ($this->valid()) {
@@ -239,11 +246,13 @@ implements ArrayAccess, Countable, Iterator
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         reset($this->_parsed);
     }
 
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return !is_null($this->key());

--- a/lib/Horde/Mail/Rfc822.php
+++ b/lib/Horde/Mail/Rfc822.php
@@ -170,7 +170,7 @@ class Horde_Mail_Rfc822
             if ($val instanceof Horde_Mail_Rfc822_Object) {
                 $this->_listob->add($val);
             } else {
-                $tmp[] = rtrim(trim($val), ',');
+                $tmp[] = rtrim(trim(is_null($val) ? "" : $val), ',');
             }
         }
 

--- a/lib/Horde/Mail/Rfc822/Group.php
+++ b/lib/Horde/Mail/Rfc822/Group.php
@@ -137,6 +137,7 @@ class Horde_Mail_Rfc822_Group
      *
      * @return integer  The number of addresses.
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->addresses);

--- a/lib/Horde/Mail/Rfc822/List.php
+++ b/lib/Horde/Mail/Rfc822/List.php
@@ -331,6 +331,7 @@ class Horde_Mail_Rfc822_List
 
     /**
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return !is_null($this[$offset]);
@@ -338,6 +339,7 @@ class Horde_Mail_Rfc822_List
 
     /**
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         try {
@@ -350,6 +352,7 @@ class Horde_Mail_Rfc822_List
 
     /**
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if ($ob = $this[$offset]) {
@@ -367,6 +370,7 @@ class Horde_Mail_Rfc822_List
 
     /**
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         if ($ob = $this[$offset]) {
@@ -387,6 +391,7 @@ class Horde_Mail_Rfc822_List
      *
      * @return integer  The number of addresses.
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->addresses);
@@ -394,6 +399,7 @@ class Horde_Mail_Rfc822_List
 
     /* Iterator methods. */
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         if (!$this->valid()) {
@@ -407,11 +413,13 @@ class Horde_Mail_Rfc822_List
             : $ob->addresses[$this->_ptr['subidx']];
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->_ptr['key'];
     }
 
+    #[\ReturnTypeWillChange]
     public function next()
     {
         if (is_null($this->_ptr['subidx'])) {
@@ -437,6 +445,7 @@ class Horde_Mail_Rfc822_List
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->_ptr = array(
@@ -453,11 +462,13 @@ class Horde_Mail_Rfc822_List
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return (!empty($this->_ptr) && isset($this->_data[$this->_ptr['idx']]));
     }
 
+    #[\ReturnTypeWillChange]
     public function seek($position)
     {
         if (!$this->valid() ||
@@ -504,6 +515,16 @@ class Horde_Mail_Rfc822_List
     }
 
     /* Serializable methods. */
+
+    public function __serialize()
+    {
+        return $this->_data;
+    }
+
+    public function __unserialize($data)
+    {
+        $this->_data = $data;
+    }
 
     public function serialize()
     {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/Mail/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/Mail/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde Mail Unit Tests">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/Mail/AddressTest.php
+++ b/test/Horde/Mail/AddressTest.php
@@ -7,7 +7,7 @@
  * @subpackage UnitTests
  */
 
-class Horde_Mail_AddressTest extends PHPUnit_Framework_TestCase
+class Horde_Mail_AddressTest extends Horde_Test_Case
 {
     /**
      * @dataProvider domainMatchProvider

--- a/test/Horde/Mail/GroupTest.php
+++ b/test/Horde/Mail/GroupTest.php
@@ -7,7 +7,7 @@
  * @subpackage UnitTests
  */
 
-class Horde_Mail_GroupTest extends PHPUnit_Framework_TestCase
+class Horde_Mail_GroupTest extends Horde_Test_Case
 {
     /**
      * @dataProvider writeAddressProvider

--- a/test/Horde/Mail/IdentificationTest.php
+++ b/test/Horde/Mail/IdentificationTest.php
@@ -23,7 +23,7 @@
  * @package    Mail
  * @subpackage UnitTests
  */
-class Horde_Mail_IdentificationTest extends PHPUnit_Framework_TestCase
+class Horde_Mail_IdentificationTest extends Horde_Test_Case
 {
     /**
      * @dataProvider provider

--- a/test/Horde/Mail/ListTest.php
+++ b/test/Horde/Mail/ListTest.php
@@ -7,11 +7,11 @@
  * @subpackage UnitTests
  */
 
-class Horde_Mail_ListTest extends PHPUnit_Framework_TestCase
+class Horde_Mail_ListTest extends Horde_Test_Case
 {
     private $rfc822;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->rfc822 = new Horde_Mail_Rfc822();
     }
@@ -437,14 +437,14 @@ class Horde_Mail_ListTest extends PHPUnit_Framework_TestCase
             4,
             count($ob)
         );
-        $this->assertInternalType('string', $ob[0]);
+        $this->assertIsString($ob[0]);
 
         $ob = $res->bare_addresses;
         $this->assertEquals(
             4,
             count($ob)
         );
-        $this->assertInternalType('string', $ob[0]);
+        $this->assertIsString($ob[0]);
 
         $ob = $res->base_addresses;
         $this->assertEquals(
@@ -465,6 +465,7 @@ class Horde_Mail_ListTest extends PHPUnit_Framework_TestCase
 
     public function testIterateEmptyArray()
     {
+        $this->expectNotToPerformAssertions();
         $ob = new Horde_Mail_Rfc822_List();
 
         foreach ($ob as $val) {
@@ -511,6 +512,7 @@ class Horde_Mail_ListTest extends PHPUnit_Framework_TestCase
 
     public function matchProvider()
     {
+        $this->expectNotToPerformAssertions();
         return array(
             array(array('foo@example.com'), false),
             array(array('bar@example.com'), false),

--- a/test/Horde/Mail/MatchTest.php
+++ b/test/Horde/Mail/MatchTest.php
@@ -7,7 +7,7 @@
  * @subpackage UnitTests
  */
 
-class Horde_Mail_MatchTest extends PHPUnit_Framework_TestCase
+class Horde_Mail_MatchTest extends Horde_Test_Case
 {
     /**
      * @dataProvider matchProvider

--- a/test/Horde/Mail/MboxParseTest.php
+++ b/test/Horde/Mail/MboxParseTest.php
@@ -23,7 +23,7 @@
  * @package    Mail
  * @subpackage UnitTests
  */
-class Horde_Mail_MboxParseTest extends PHPUnit_Framework_TestCase
+class Horde_Mail_MboxParseTest extends Horde_Test_Case
 {
     public function testMboxParse()
     {
@@ -41,8 +41,7 @@ class Horde_Mail_MboxParseTest extends PHPUnit_Framework_TestCase
                 $key
             );
 
-            $this->assertInternalType(
-                'array',
+            $this->assertIsArray(
                 $val
             );
 
@@ -67,8 +66,7 @@ class Horde_Mail_MboxParseTest extends PHPUnit_Framework_TestCase
 
         $val = $parse[0];
 
-        $this->assertInternalType(
-            'array',
+        $this->assertIsArray(
             $val
         );
 
@@ -92,11 +90,9 @@ class Horde_Mail_MboxParseTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Mail_Exception
-     */
     public function testBadData()
     {
+        $this->expectException('Horde_Mail_Exception');
         new Horde_Mail_Mbox_Parse(__DIR__ . '/noexist');
     }
 

--- a/test/Horde/Mail/ObjectTest.php
+++ b/test/Horde/Mail/ObjectTest.php
@@ -7,7 +7,7 @@
  * @subpackage UnitTests
  */
 
-class Horde_Mail_ObjectTest extends PHPUnit_Framework_TestCase
+class Horde_Mail_ObjectTest extends Horde_Test_Case
 {
     public function testWriteAddress()
     {

--- a/test/Horde/Mail/ParseTest.php
+++ b/test/Horde/Mail/ParseTest.php
@@ -7,11 +7,11 @@
  * @subpackage UnitTests
  */
 
-class Horde_Mail_ParseTest extends PHPUnit_Framework_TestCase
+class Horde_Mail_ParseTest extends Horde_Test_Case
 {
     private $rfc822;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->rfc822 = new Horde_Mail_Rfc822();
     }
@@ -42,8 +42,7 @@ class Horde_Mail_ParseTest extends PHPUnit_Framework_TestCase
             'mydomain.com',
             $ob->host
         );
-        $this->assertInternalType(
-            'array',
+        $this->assertIsArray(
             $ob->comment
         );
         $this->assertEquals(
@@ -63,6 +62,7 @@ class Horde_Mail_ParseTest extends PHPUnit_Framework_TestCase
      * */
     public function testParseBug9137($name, $email)
     {
+        $this->expectNotToPerformAssertions();
         /* Throws Exception on error. */
         $this->rfc822->parseAddressList(
             '"' . addslashes($name) . '" <' . $email . '>'
@@ -71,6 +71,7 @@ class Horde_Mail_ParseTest extends PHPUnit_Framework_TestCase
 
     public function parseBug9137Provider()
     {
+        $this->expectNotToPerformAssertions();
         return array(
             array('John Doe', 'test@example.com'),
             array('John Doe\\', 'test@example.com'),
@@ -86,6 +87,7 @@ class Horde_Mail_ParseTest extends PHPUnit_Framework_TestCase
      */
     public function testParseBug9137Take2($raw, $fail)
     {
+        $this->expectNotToPerformAssertions();
         try {
             $this->rfc822->parseAddressList($raw, array(
                 'validate' => true
@@ -102,6 +104,7 @@ class Horde_Mail_ParseTest extends PHPUnit_Framework_TestCase
 
     public function parseBug9137Take2Provider()
     {
+        $this->expectNotToPerformAssertions();
         return array(
             array('"John Doe" <test@example.com>', false),
             array('"John Doe' . chr(92) . '" <test@example.com>', true),
@@ -123,7 +126,7 @@ class Horde_Mail_ParseTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($result instanceof Horde_Mail_Rfc822_List);
         $this->assertTrue($result[0] instanceof Horde_Mail_Rfc822_Address);
         $this->assertEquals($result[0]->personal, '');
-        $this->assertInternalType('array', $result[0]->comment);
+        $this->assertIsArray($result[0]->comment);
         $this->assertEquals($result[0]->comment, array());
         $this->assertEquals($result[0]->mailbox, 'user');
         $this->assertEquals($result[0]->host, 'example.com');
@@ -140,23 +143,23 @@ class Horde_Mail_ParseTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($result[0]->addresses instanceof Horde_Mail_Rfc822_GroupList);
         $this->assertEquals(0, $result[0]->addresses->groupCount());
 
-        $this->assertInternalType('object', $result[0]->addresses[0]);
+        $this->assertIsObject($result[0]->addresses[0]);
         $this->assertEquals($result[0]->addresses[0]->personal, 'Richard');
-        $this->assertInternalType('array', $result[0]->addresses[0]->comment);
+        $this->assertIsArray($result[0]->addresses[0]->comment);
         $this->assertEquals($result[0]->addresses[0]->comment[0], 'A comment');
         $this->assertEquals($result[0]->addresses[0]->mailbox, 'richard');
         $this->assertEquals($result[0]->addresses[0]->host, 'example.com');
 
-        $this->assertInternalType('object', $result[0]->addresses[1]);
+        $this->assertIsObject($result[0]->addresses[1]);
         $this->assertEquals($result[0]->addresses[1]->personal, '');
-        $this->assertInternalType('array', $result[0]->addresses[1]->comment);
+        $this->assertIsArray($result[0]->addresses[1]->comment);
         $this->assertEquals($result[0]->addresses[1]->comment[0], 'Ted Bloggs');
         $this->assertEquals($result[0]->addresses[1]->mailbox, 'ted');
         $this->assertEquals($result[0]->addresses[1]->host, 'example.com');
 
-        $this->assertInternalType('object', $result[0]->addresses[2]);
+        $this->assertIsObject($result[0]->addresses[2]);
         $this->assertEquals($result[0]->addresses[2]->personal, '');
-        $this->assertInternalType('array', $result[0]->addresses[2]->comment);
+        $this->assertIsArray($result[0]->addresses[2]->comment);
         $this->assertEquals($result[0]->addresses[2]->comment, array());
         $this->assertEquals($result[0]->addresses[2]->mailbox, 'Barney');
         $this->assertEmpty($result[0]->addresses[2]->host);
@@ -170,7 +173,7 @@ class Horde_Mail_ParseTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($result instanceof Horde_Mail_Rfc822_List);
         $this->assertTrue($result[0] instanceof Horde_Mail_Rfc822_Address);
         $this->assertEquals($result[0]->personal, '');
-        $this->assertInternalType('array', $result[0]->comment);
+        $this->assertIsArray($result[0]->comment);
         $this->assertEquals($result[0]->comment, array());
         $this->assertEquals($result[0]->mailbox, 'Jon Parise');
         $this->assertEquals($result[0]->host, 'php.net');
@@ -208,6 +211,7 @@ class Horde_Mail_ParseTest extends PHPUnit_Framework_TestCase
 
     public function testBug9525()
     {
+        $this->expectNotToPerformAssertions();
         try {
             $ob = $this->rfc822->parseAddressList(
                 'ß <test@example.com>',
@@ -421,6 +425,7 @@ class Horde_Mail_ParseTest extends PHPUnit_Framework_TestCase
 
     public function utf8CharactersInAddressProvider()
     {
+        $this->expectNotToPerformAssertions();
         return array(
             array('fooççç@example.com', true),
             array('Jøran Øygårdvær <jøran@example.com>', true),
@@ -587,6 +592,7 @@ class Horde_Mail_ParseTest extends PHPUnit_Framework_TestCase
      */
     public function testBareMailboxWithoutDefaultDomainWhenValidating($addr)
     {
+        $this->expectNotToPerformAssertions();
         try {
             $this->rfc822->parseAddressList($addr, array(
                 'default_domain' => null,
@@ -598,6 +604,7 @@ class Horde_Mail_ParseTest extends PHPUnit_Framework_TestCase
 
     public function bareMailboxWithoutDefaultDomainProvider()
     {
+        $this->expectNotToPerformAssertions();
         return array(
             array('foo'),
             array('foo@')

--- a/test/Horde/Mail/SendTest.php
+++ b/test/Horde/Mail/SendTest.php
@@ -7,11 +7,12 @@
  * @subpackage UnitTests
  */
 
-class Horde_Mail_SendTest extends PHPUnit_Framework_TestCase
+class Horde_Mail_SendTest extends Horde_Test_Case
 {
     /* Test case for mixed EOLs. */
     public function testMixedEOLs()
     {
+        $this->expectNotToPerformAssertions();
         $ob = new Horde_Mail_Transport_Mock();
         $ob->sep = "\n";
 
@@ -76,6 +77,7 @@ class Horde_Mail_SendTest extends PHPUnit_Framework_TestCase
 
     public function testMissingFrom()
     {
+        $this->expectNotToPerformAssertions();
         $ob = new Horde_Mail_Transport_Mock();
 
         try {

--- a/test/Horde/Mail/phpunit.xml
+++ b/test/Horde/Mail/phpunit.xml
@@ -1,0 +1,1 @@
+<phpunit bootstrap="bootstrap.php"></phpunit>


### PR DESCRIPTION
- Debian changes: Adapt to PHPUnit 8.x and 9.x API. https://salsa.debian.org/horde-team/php-horde-mail/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian changes: 1011_php8.1.patch https://salsa.debian.org/horde-team/php-horde-mail/-/blob/debian-sid/debian/patches/1011_php8.1.patch
