### PR TITLE
Fix use statement warning

### DIFF
--- a/lib/Horde/Mail/Rfc822/List.php
+++ b/lib/Horde/Mail/Rfc822/List.php
@@ -11,8 +11,6 @@
  * @package   Mail
  */
 
-use \Horde_Mime_Headers_Addresses;
-
 /**
  * Container object for a collection of RFC 822 elements.
  *


### PR DESCRIPTION
Fixes:
```
PHP Warning:  The use statement with non-compound name 'Horde_Mime_Headers_Addresses' has no effect in /home/angelo/git/forks/Mail/lib/Horde/Mail/Rfc822/List.php on line 14
```