### PR TITLE
fix: backport community fix from bytestream fork

### DIFF
--- a/lib/Horde/Mail/Rfc822.php
+++ b/lib/Horde/Mail/Rfc822.php
@@ -802,7 +802,7 @@ class Horde_Mail_Rfc822
             return strcspn($chr, $validate);
         }
 
-        $ord = ord($chr);
+        $ord = empty($chr) ? 0 : ord($chr);
 
         /* UTF-8 characters check. */
         if ($ord > 127) {


### PR DESCRIPTION
Original-Author: David Dreschner <github-2017@dreschner.net> (ord() empty string deprecation, 5054666)
