### PR TITLE
Improve personal name handling in Address.php

### DIFF
--- a/lib/Horde/Mail/Rfc822/Address.php
+++ b/lib/Horde/Mail/Rfc822/Address.php
@@ -103,9 +103,17 @@ class Horde_Mail_Rfc822_Address extends Horde_Mail_Rfc822_Object
                 break;
 
             case 'personal':
-                $this->_personal = !empty($value)
-                    ? Rfc2047::decode($value)
-                    : null;
+                if (empty($value) || !is_scalar($value)) {
+                    $this->_personal = null;
+                    break;
+                }
+                $value = (string)$value;
+                try {
+                    $this->_personal = Rfc2047::decode($value);
+                } catch (Throwable $e) {
+                    // Gracefully keep raw value if malformed MIME data is set.
+                    $this->_personal = $value;
+                }
                 break;
         }
     }


### PR DESCRIPTION
# PR Title
Harden RFC822 personal-name handling against invalid identity data

## Summary
This PR prevents portal rendering from fatally crashing when malformed or unexpected identity/fullname values are passed into `Horde_Mail_Rfc822_Address`.

- Adds input validation in `Address::__set('personal', ...)` to ignore non-scalar values instead of passing invalid data to MIME decoding.
- Casts scalar values to string before decode to satisfy strict `Rfc2047::decode(string)` typing.
- Wraps `Rfc2047::decode()` in a `try/catch` and falls back to the raw string when decoding fails (for example, malformed encoded-word input), preventing unhandled exceptions.

## Why
Recent strict typing and decode behavior in Horde mail exposed bad preference-data paths (from identity/fullname resolution) and caused runtime fatals in the portal flow.  
This patch hardens that path so corrupted or unusual user profile data cannot take down page rendering.

## Files Changed
- `vendor/horde/mail/lib/Horde/Mail/Rfc822/Address.php`

## Test Plan
- Open `services/portal/index.php` with a normal identity and verify the page loads.
- Reproduce with malformed identity fullname values (non-scalar / broken MIME-encoded text) and verify no fatal occurs.
- Confirm displayed personal name falls back gracefully (`null` or raw string) instead of crashing.
- Run syntax check:

```bash
php -l vendor/horde/mail/lib/Horde/Mail/Rfc822/Address.php
```