### PR TITLE
fix: recover from unencoded ':' in display-name (lenient mode)

### DIFF
--- a/lib/Horde/Mail/Rfc822.php
+++ b/lib/Horde/Mail/Rfc822.php
@@ -292,12 +292,36 @@ class Horde_Mail_Rfc822
     protected function _parseAddress()
     {
         $start = $this->_ptr;
-        if (!$this->_parseGroup()) {
-            $this->_ptr = $start;
-            if ($mbox = $this->_parseMailbox()) {
-                $this->_listob->add($mbox);
+        try {
+            if ($this->_parseGroup()) {
+                return;
+            }
+        } catch (Horde_Mail_Exception $e) {
+            /* In non-strict mode, if an unterminated "group" is actually a
+             * name-addr with an unencoded ':' in the display-name (e.g.
+             * "ACME : The professional network <addr>"), recover by
+             * rewinding and falling back to _parseMailbox below. The
+             * fallback only triggers if a '<' is present in the current
+             * segment (before the next ',' or ';'). */
+            if (!empty($this->_params['validate'])
+                || !$this->_hasAngleAddrBeforeSeparator($start)) {
+                throw $e;
             }
         }
+        $this->_ptr = $start;
+        if ($mbox = $this->_parseMailbox()) {
+            $this->_listob->add($mbox);
+        }
+    }
+
+    /**
+     * Returns true if a '<' is present between $from and the next ',' or ';'.
+     */
+    protected function _hasAngleAddrBeforeSeparator($from)
+    {
+        $segment = substr($this->_data, $from);
+        $stop = strcspn($segment, '<,;');
+        return $stop < strlen($segment) && $segment[$stop] === '<';
     }
 
     /**
@@ -387,6 +411,22 @@ class Horde_Mail_Rfc822
         if ($ob = $this->_parseAngleAddr()) {
             $ob->personal = $personal;
             return $ob;
+        }
+
+        /* In non-strict mode, tolerate disallowed characters (e.g. ':') in
+         * the display-name by consuming everything up to the next angle-addr
+         * within the current segment (before the next ',' or ';'). */
+        if (empty($this->_params['validate']) && ($this->_curr() !== false)) {
+            $segment = substr($this->_data, $this->_ptr);
+            $stop = strcspn($segment, '<,;');
+            if ($stop < strlen($segment) && $segment[$stop] === '<') {
+                $extra = rtrim(substr($segment, 0, $stop));
+                $this->_ptr += $stop;
+                if ($ob = $this->_parseAngleAddr()) {
+                    $ob->personal = rtrim($personal . ' ' . $extra);
+                    return $ob;
+                }
+            }
         }
 
         return false;

--- a/src/Rfc822/Rfc822Parser.php
+++ b/src/Rfc822/Rfc822Parser.php
@@ -160,13 +160,34 @@ final class Rfc822Parser
     private function parseAddress(Rfc822ParserConfig $cfg): void
     {
         $start = $this->ptr;
-        if (!$this->parseGroup($cfg)) {
-            $this->ptr = $start;
-            $mbox = $this->parseMailbox($cfg);
-            if ($mbox !== null) {
-                $this->listob->add($mbox);
+        try {
+            if ($this->parseGroup($cfg)) {
+                return;
+            }
+        } catch (ParseException $e) {
+            /* In lenient mode, if an unterminated "group" is actually a
+             * name-addr with an unencoded ':' in the display-name (e.g.
+             * "ACME : The professional network <addr>"), recover by
+             * rewinding and falling back to parseMailbox below. The
+             * fallback only triggers if a '<' is present in the current
+             * segment (before the next ',' or ';'). */
+            if ($this->activeValidation !== ValidationMode::Lenient
+                || !$this->hasAngleAddrBeforeSeparator($start)) {
+                throw $e;
             }
         }
+        $this->ptr = $start;
+        $mbox = $this->parseMailbox($cfg);
+        if ($mbox !== null) {
+            $this->listob->add($mbox);
+        }
+    }
+
+    private function hasAngleAddrBeforeSeparator(int $from): bool
+    {
+        $segment = substr($this->data, $from);
+        $stop = strcspn($segment, '<,;');
+        return $stop < strlen($segment) && $segment[$stop] === '<';
     }
 
     private function parseGroup(Rfc822ParserConfig $cfg): bool
@@ -261,6 +282,25 @@ final class Rfc822Parser
         $this->parsePhrase($personal);
 
         $ob = $this->parseAngleAddr($cfg);
+
+        /* In lenient mode, tolerate disallowed characters (e.g. ':') in the
+         * display-name by consuming everything up to the next angle-addr
+         * within the current segment (before the next ',' or ';'). */
+        if ($ob === null
+            && $this->activeValidation === ValidationMode::Lenient
+            && $this->curr() !== false) {
+            $segment = substr($this->data, $this->ptr);
+            $stop = strcspn($segment, '<,;');
+            if ($stop < strlen($segment) && $segment[$stop] === '<') {
+                $extra = rtrim(substr($segment, 0, $stop));
+                $this->ptr += $stop;
+                $ob = $this->parseAngleAddr($cfg);
+                if ($ob !== null) {
+                    $personal = rtrim($personal . ' ' . $extra);
+                }
+            }
+        }
+
         if ($ob === null) {
             return null;
         }

--- a/test/unit/ParseTest.php
+++ b/test/unit/ParseTest.php
@@ -473,6 +473,50 @@ class ParseTest extends TestCase
 
     }
 
+    /**
+     * RFC 5322 disallows ':' in an unquoted phrase, but mailers like
+     * AlumnForce/Swift produce From headers such as
+     *   "CONNECT : Le réseau ... <addr@host>"
+     * In non-strict mode the parser must recover and still return the address.
+     */
+    public function testParsingUnencodedColonInDisplayName()
+    {
+        $ob = $this->rfc822->parseAddressList(
+            'ACME : The professional network <contact@example.com>'
+        );
+
+        $this->assertEquals(1, count($ob));
+        $this->assertEquals('contact@example.com', $ob[0]->bare_address);
+        $this->assertEquals(
+            'ACME : The professional network',
+            $ob[0]->personal
+        );
+    }
+
+    public function testParsingUnencodedColonInDisplayNameFollowedByAddress()
+    {
+        $ob = $this->rfc822->parseAddressList(
+            'ACME : The professional network <a@b.com>, c@d.com'
+        );
+
+        $this->assertEquals(2, count($ob));
+        $this->assertEquals('a@b.com', $ob[0]->bare_address);
+        $this->assertEquals(
+            'ACME : The professional network',
+            $ob[0]->personal
+        );
+        $this->assertEquals('c@d.com', $ob[1]->bare_address);
+    }
+
+    public function testParsingUnencodedColonInDisplayNameStrictThrows()
+    {
+        $this->expectException('Horde_Mail_Exception');
+        $this->rfc822->parseAddressList(
+            'ACME : The professional network <contact@example.com>',
+            ['validate' => true]
+        );
+    }
+
     public function testParsingSimpleString()
     {
         $email = 'Test';

--- a/test/unit/Rfc822/Rfc822ParserTest.php
+++ b/test/unit/Rfc822/Rfc822ParserTest.php
@@ -498,6 +498,41 @@ class Rfc822ParserTest extends TestCase
         $this->assertSame('example.com', $list->first()->host);
     }
 
+    // ── Unencoded ':' in display-name (lenient mode) ─────────────────
+    // RFC 5322 disallows ':' in an unquoted phrase, but mailers like
+    // AlumnForce/Swift produce From headers such as
+    //   "CONNECT : Le réseau ... <addr@host>"
+    // Make sure such malformed name-addr still yields the address.
+
+    public function testUnencodedColonInDisplayNameLenient(): void
+    {
+        $list = $this->parser()->parseAddressList(
+            'ACME : The professional network <contact@example.com>'
+        );
+        $this->assertCount(1, $list);
+        $addr = $list->first();
+        $this->assertSame('contact@example.com', $addr->bareAddress());
+        $this->assertSame('ACME : The professional network', $addr->personal);
+    }
+
+    public function testUnencodedColonInDisplayNameFollowedByAnotherAddress(): void
+    {
+        $list = $this->parser()->parseAddressList(
+            'ACME : The professional network <a@b.com>, c@d.com'
+        );
+        $this->assertCount(2, $list);
+        $this->assertSame('a@b.com', $list->first()->bareAddress());
+        $this->assertSame('ACME : The professional network', $list->first()->personal);
+    }
+
+    public function testUnencodedColonInDisplayNameStrictStillThrows(): void
+    {
+        $this->expectException(ParseException::class);
+        $this->strictParser()->parseAddressList(
+            'ACME : The professional network <contact@example.com>'
+        );
+    }
+
     // ── Uncommon TLD ─────────────────────────────────────────────────
 
     public function testUncommonTldAccepted(): void


### PR DESCRIPTION
Note: Claude proposed a much cleaner fix and tests than I would have. Feel free to close this PR if that's a problem or if you prefer a different approach.

RFC 5322 disallows ':' in an unquoted phrase, but mailers such as AlumnForce/Swift produce name-addr headers like

  "ACME : The professional network <addr@host>"

In lenient/non-strict mode, the parser raised an internal "Error when parsing group" and silently dropped the address. It now recovers when a '<' is present before the next ',' or ';' and returns the mailbox with the full original text as the personal part. Strict mode still rejects such input.

Co-Authored-By: Claude Opus 4.7