### PR TITLE
Replace [$address] with (array)$address in Horde_Mail_Rfc822::parseAddressList()

### DIFF
--- a/lib/Horde/Mail/Rfc822.php
+++ b/lib/Horde/Mail/Rfc822.php
@@ -162,12 +162,8 @@ class Horde_Mail_Rfc822
             ? new Horde_Mail_Rfc822_List()
             : new Horde_Mail_Rfc822_GroupList();
 
-        if (!is_array($address)) {
-            $address = [$address];
-        }
-
         $tmp = [];
-        foreach ($address as $val) {
+        foreach ((array) $address as $val) {
             if ($val instanceof Horde_Mail_Rfc822_Object) {
                 $this->_listob->add($val);
             } else {
@@ -175,7 +171,7 @@ class Horde_Mail_Rfc822
             }
         }
 
-        if (!empty($tmp)) {
+        if ($tmp) {
             $this->_data = implode(',', $tmp);
             $this->_datalen = strlen($this->_data);
             $this->_ptr = 0;


### PR DESCRIPTION
This gracefully fixes trim(null) issue if $address is null.